### PR TITLE
simple Data constructor. Look to change

### DIFF
--- a/py-gen/src/functions/reduce_over_chunks.py
+++ b/py-gen/src/functions/reduce_over_chunks.py
@@ -12,4 +12,9 @@ class ReduceOverChunks(Function):
         ## is in size of 2 and scale of the square of elements of a 
         ## hypersphere. Perhaps we'll 'realize' that form here for use
         ## elsewhere. 
-        pass
+        chunks = []
+        for index in range(0, len(array), size):
+            point = data[index:index+size]
+            chunks.append(Point(l=point)
+
+        return List(chunks)


### PR DESCRIPTION
Here we've simply partitioned without regard to lengths not divisible by size. Look to implement with length awareness. What's more, __call__ is returning something not array. Under normal circumstances, this operation would be done within call_data method. Look to reconstruct again with this in mind. Perhaps we keep the logic of array manipulation in __call__ and construction within call_data. Pattern match on 'containers' with recursive calls to call_data and 'geometry' with calls to __call__, capture chunked arrays and reconstitute into Lists of the given type. 