### PR TITLE
update ROC strict __call__

### DIFF
--- a/py-gen/src/functions/reduce_over_chunks.py
+++ b/py-gen/src/functions/reduce_over_chunks.py
@@ -3,7 +3,7 @@ from src.typeclass import Function
 class ReduceOverChunks(Function):
     def __init__(self, size, scales):
         self.size = size
-        self.scale = scale
+        self.scales = scales
 
     def __call__(self, data : array):
         ## retrieve data from Data and chunck into some 'chunk_size'
@@ -12,9 +12,8 @@ class ReduceOverChunks(Function):
         ## is in size of 2 and scale of the square of elements of a 
         ## hypersphere. Perhaps we'll 'realize' that form here for use
         ## elsewhere. 
-        chunks = []
+        output = zeros((self.size))
         for index in range(0, len(array), size):
-            point = data[index:index+size]
-            chunks.append(Point(l=point)
+            output += scales[index//self.size]*data[index:index+size]
 
-        return List(chunks)
+        return output


### PR DESCRIPTION
Having slept on it, I've reconstructed ROC so as to remain strictly within operations on array. It's effectively a dot product. Unfortunately, this is done in such a way as to 'lose' information in that there's no intermediate step between 'chunking' and synthesizing. It may be worth taking some time to consider how to make this two computations with chunk and dot as its components. For the moment, we'll avoid it and implement as described above in 'Montipora' version of our generative art program.